### PR TITLE
[protocol] sbt bsp generator support & move the connect action to the background

### DIFF
--- a/protocol/src/main/kotlin/org/jetbrains/protocol/connection/BspConnectionDetailsGenerator.kt
+++ b/protocol/src/main/kotlin/org/jetbrains/protocol/connection/BspConnectionDetailsGenerator.kt
@@ -1,14 +1,35 @@
 package org.jetbrains.protocol.connection
 
 import com.intellij.openapi.vfs.VirtualFile
+import java.io.OutputStream
 
 public interface BspConnectionDetailsGenerator {
+  public fun executeAndWait(command: String, projectPath: VirtualFile, outputStream: OutputStream) {
+    // TODO - consider verbosing what command is being executed
+    val consoleProcess = Runtime.getRuntime().exec(
+      command,
+      emptyArray(),
+      projectPath.toNioPath().toFile()
+    )
+    consoleProcess.inputStream.transferTo(outputStream)
+    consoleProcess.waitFor()
+  }
+
+  public fun getChild(root: VirtualFile?, path: List<String>): VirtualFile? {
+    val found: VirtualFile? = path.fold(root) {
+      vf: VirtualFile?, child: String ->
+      vf?.refresh(false, false)
+      vf?.findChild(child)
+    }
+    found?.refresh(false, false)
+    return found
+  }
 
   public fun name(): String
 
   public fun canGenerateBspConnectionDetailsFile(projectPath: VirtualFile): Boolean
 
-  public fun generateBspConnectionDetailsFile(projectPath: VirtualFile): VirtualFile
+  public fun generateBspConnectionDetailsFile(projectPath: VirtualFile, outputStream: OutputStream): VirtualFile
 }
 
 public class BspConnectionDetailsGeneratorProvider(
@@ -26,8 +47,8 @@ public class BspConnectionDetailsGeneratorProvider(
   public fun availableGeneratorsNames(): List<String> =
     availableBspConnectionDetailsGenerators.map { it.name() }
 
-  public fun generateBspConnectionDetailFileForGeneratorWithName(generatorName: String): VirtualFile? =
+  public fun generateBspConnectionDetailFileForGeneratorWithName(generatorName: String, outputStream: OutputStream): VirtualFile? =
     availableBspConnectionDetailsGenerators
       .find { it.name() == generatorName }
-      ?.generateBspConnectionDetailsFile(projectPath)
+      ?.generateBspConnectionDetailsFile(projectPath, outputStream)
 }

--- a/protocol/src/test/kotlin/org/jetbrains/protocol/connection/BspConnectionDetailsGeneratorProviderTest.kt
+++ b/protocol/src/test/kotlin/org/jetbrains/protocol/connection/BspConnectionDetailsGeneratorProviderTest.kt
@@ -1,17 +1,15 @@
 package org.jetbrains.protocol.connection
 
 import com.intellij.openapi.vfs.VirtualFile
-import com.intellij.util.io.createDirectories
 import com.intellij.util.io.createFile
 import io.kotest.matchers.collections.shouldContainExactlyInAnyOrder
-import io.kotest.matchers.should
 import io.kotest.matchers.shouldBe
 import org.jetbrains.workspace.model.test.framework.MockProjectBaseTest
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
+import java.io.OutputStream
 import java.nio.file.Path
-import kotlin.io.path.Path
 import kotlin.io.path.createTempDirectory
 
 private object GeneratorWhichCantGenerate : BspConnectionDetailsGenerator {
@@ -20,7 +18,7 @@ private object GeneratorWhichCantGenerate : BspConnectionDetailsGenerator {
 
   override fun canGenerateBspConnectionDetailsFile(projectPath: VirtualFile): Boolean = false
 
-  override fun generateBspConnectionDetailsFile(projectPath: VirtualFile): VirtualFile = projectPath
+  override fun generateBspConnectionDetailsFile(projectPath: VirtualFile, outputStream: OutputStream): VirtualFile = projectPath
 }
 
 private class GeneratorWhichCanGenerate(private val name: String, private val generatedFilePath: VirtualFile) :
@@ -32,7 +30,7 @@ private class GeneratorWhichCanGenerate(private val name: String, private val ge
 
   override fun canGenerateBspConnectionDetailsFile(projectPath: VirtualFile): Boolean = true
 
-  override fun generateBspConnectionDetailsFile(projectPath: VirtualFile): VirtualFile {
+  override fun generateBspConnectionDetailsFile(projectPath: VirtualFile, outputStream: OutputStream): VirtualFile {
     hasGenerated = true
 
     return generatedFilePath
@@ -99,7 +97,7 @@ class BspConnectionDetailsGeneratorProviderTest : MockProjectBaseTest() {
     provider.canGenerateAnyBspConnectionDetailsFile() shouldBe true
     provider.availableGeneratorsNames() shouldContainExactlyInAnyOrder listOf("generator 1")
 
-    provider.generateBspConnectionDetailFileForGeneratorWithName("wrong name") shouldBe null
+    provider.generateBspConnectionDetailFileForGeneratorWithName("wrong name", OutputStream.nullOutputStream()) shouldBe null
     generator.hasGenerated shouldBe false
   }
 
@@ -116,7 +114,7 @@ class BspConnectionDetailsGeneratorProviderTest : MockProjectBaseTest() {
     provider.canGenerateAnyBspConnectionDetailsFile() shouldBe true
     provider.availableGeneratorsNames() shouldContainExactlyInAnyOrder listOf("generator 1")
 
-    provider.generateBspConnectionDetailFileForGeneratorWithName("generator 1") shouldBe generatedVirtualFile
+    provider.generateBspConnectionDetailFileForGeneratorWithName("generator 1", OutputStream.nullOutputStream()) shouldBe generatedVirtualFile
     generator.hasGenerated shouldBe true
   }
 
@@ -140,7 +138,7 @@ class BspConnectionDetailsGeneratorProviderTest : MockProjectBaseTest() {
       "generator 3"
     )
 
-    provider.generateBspConnectionDetailFileForGeneratorWithName("generator 2") shouldBe generatedVirtualFile
+    provider.generateBspConnectionDetailFileForGeneratorWithName("generator 2", OutputStream.nullOutputStream()) shouldBe generatedVirtualFile
     generator1.hasGenerated shouldBe false
     generator2.hasGenerated shouldBe true
     generator3.hasGenerated shouldBe false
@@ -168,7 +166,7 @@ class BspConnectionDetailsGeneratorProviderTest : MockProjectBaseTest() {
       "generator 3"
     )
 
-    provider.generateBspConnectionDetailFileForGeneratorWithName("generator 2") shouldBe generatedVirtualFile
+    provider.generateBspConnectionDetailFileForGeneratorWithName("generator 2", OutputStream.nullOutputStream()) shouldBe generatedVirtualFile
     generator1.hasGenerated shouldBe false
     generator21.hasGenerated shouldBe true
     generator22.hasGenerated shouldBe false

--- a/src/main/kotlin/org/jetbrains/plugins/bsp/import/BspProjectOpenProcessor.kt
+++ b/src/main/kotlin/org/jetbrains/plugins/bsp/import/BspProjectOpenProcessor.kt
@@ -15,10 +15,8 @@ import org.jetbrains.plugins.bsp.config.BspPluginBundle
 import org.jetbrains.plugins.bsp.config.BspPluginIcons
 import org.jetbrains.plugins.bsp.extension.points.BspConnectionDetailsGeneratorExtension
 import org.jetbrains.plugins.bsp.services.BspConnectionService
-import org.jetbrains.plugins.bsp.services.BspUtilService
 import org.jetbrains.protocol.connection.BspConnectionDetailsGeneratorProvider
 import org.jetbrains.protocol.connection.BspConnectionFilesProvider
-import org.jetbrains.protocol.connection.LocatedBspConnectionDetailsParser
 import javax.swing.Icon
 import javax.swing.JComponent
 
@@ -51,21 +49,17 @@ public class BspProjectOpenProcessor : ProjectOpenProcessor() {
 
     return if (dialog.showAndGet()) {
       val project = PlatformProjectOpenProcessor.getInstance().doOpenProject(virtualFile, projectToClose, forceOpenInNewFrame)
-      val bspUtilService = BspUtilService.getInstance()
 
       if (project != null) {
         val connectionService = BspConnectionService.getInstance(project)
 
+        connectionService.bspConnectionDetailsGeneratorProvider = bspConnectionDetailsGeneratorProvider
         if (dialog.buildToolUsed.selected()) {
-          val xd = dialog.buildTool
-          val xd1 = bspConnectionDetailsGeneratorProvider.generateBspConnectionDetailFileForGeneratorWithName(xd)
-          val xd2 = LocatedBspConnectionDetailsParser.parseFromFile(xd1!!)
-          bspUtilService.connectionFile[project.locationHash] = xd2!!
-          connectionService.connect(xd2)
+          connectionService.dialogBuildToolUsed = true
+          connectionService.dialogBuildToolName = dialog.buildTool
         } else {
-          val xd = bspConnectionFilesProvider.connectionFiles[dialog.connectionFileId]
-          bspUtilService.connectionFile[project.locationHash] = xd
-          connectionService.connect(xd)
+          connectionService.dialogBuildToolUsed = false
+          connectionService.dialogConnectionFile = bspConnectionFilesProvider.connectionFiles[dialog.connectionFileId]
         }
 
         project

--- a/src/main/kotlin/org/jetbrains/plugins/bsp/ui/console/ConsoleOutputStream.kt
+++ b/src/main/kotlin/org/jetbrains/plugins/bsp/ui/console/ConsoleOutputStream.kt
@@ -1,0 +1,17 @@
+package org.jetbrains.plugins.bsp.ui.console
+// Temporary location - another package might be more suitable
+
+import java.io.OutputStream
+
+public class ConsoleOutputStream(private val id: Any?, private val bspSyncConsole: BspSyncConsole) : OutputStream() {
+  private var line: StringBuffer = StringBuffer()
+
+  override fun write(b: Int) {
+    val c: Char = (b and 255).toChar()
+    line.append(c)
+    if (c == '\n') {
+      bspSyncConsole.addMessage(id, line.toString())
+      line = StringBuffer()
+    }
+  }
+}

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -15,6 +15,9 @@
     <bspConnectionDetailsGeneratorExtension
       implementation="org.jetbrains.plugins.bsp.extension.points.TemporaryBazelBspConnectionDetailsGenerator"
     />
+    <bspConnectionDetailsGeneratorExtension
+      implementation="org.jetbrains.plugins.bsp.extension.points.TemporarySbtBspConnectionDetailsGenerator"
+    />
 
     <projectOpenProcessor
       implementation="org.jetbrains.plugins.bsp.import.BspProjectOpenProcessor"/>


### PR DESCRIPTION
This PR moves import actions (including obtaining config files) to the background, thus avoiding IntelliJ freeze while loading a project. Also, implementing support for build-tools has been made much easier (SBT support needs below 10 lines now)