### PR TITLE
[widget] display build targets as a tree

### DIFF
--- a/src/main/kotlin/org/jetbrains/plugins/bsp/extension/points/BspBuildTargetClassifierExtension.kt
+++ b/src/main/kotlin/org/jetbrains/plugins/bsp/extension/points/BspBuildTargetClassifierExtension.kt
@@ -1,0 +1,41 @@
+package org.jetbrains.plugins.bsp.extension.points
+
+import ch.epfl.scala.bsp4j.BuildTarget
+import com.intellij.openapi.extensions.ExtensionPointName
+import org.jetbrains.plugins.bsp.ui.widgets.tool.window.utils.BspBuildTargetClassifier
+
+public interface BspBuildTargetClassifierExtension : BspBuildTargetClassifier {
+  public companion object {
+    private val ep =
+      ExtensionPointName.create<BspBuildTargetClassifierExtension>("com.intellij.bspBuildTargetClassifierExtension")
+
+    public fun extensions(): List<BspBuildTargetClassifierExtension> =
+      ep.extensionList
+  }
+}
+
+
+public class TemporaryTestTargetClassifier : BspBuildTargetClassifierExtension {
+  override fun name(): String = "bazelbsp"
+
+  override fun separator(): String = "/"
+
+  override fun getBuildTargetPath(buildTarget: BuildTarget): List<String> {
+    val uri = buildTarget.id.uri
+    return if (uri.startsWith("//") && uri.contains(':')) {
+      uri
+        .dropWhile { it == '/' }
+        .takeWhile { it != ':' }
+        .split('/')
+        .filter { it.isNotEmpty() }
+    } else emptyList()
+  }
+
+  override fun getBuildTargetName(buildTarget: BuildTarget): String {
+    val uri = buildTarget.id.uri
+    return if (uri.startsWith("//") && uri.contains(':')) {
+      ":" + uri
+        .takeLastWhile { it != ':' }
+    } else buildTarget.displayName
+  }
+}

--- a/src/main/kotlin/org/jetbrains/plugins/bsp/services/BspConnectionService.kt
+++ b/src/main/kotlin/org/jetbrains/plugins/bsp/services/BspConnectionService.kt
@@ -40,6 +40,9 @@ public class BspConnectionService(private val project: Project) {
   public var dialogConnectionFile: LocatedBspConnectionDetails? = null
   public var bspConnectionDetailsGeneratorProvider: BspConnectionDetailsGeneratorProvider? = null
 
+  public var toolName: String? = null
+    private set
+
   public fun connect(connectionFile: LocatedBspConnectionDetails) {
     val process = createAndStartProcess(connectionFile.bspConnectionDetails)
     val bspSyncConsoleService = BspSyncConsoleService.getInstance(project)
@@ -78,9 +81,11 @@ public class BspConnectionService(private val project: Project) {
           ConsoleOutputStream("bsp-obtain-config", bspSyncConsole)
         )
         val xd2 = LocatedBspConnectionDetailsParser.parseFromFile(xd1!!)
+        this.toolName = xd2?.bspConnectionDetails?.name
         bspUtilService.bspConnectionDetails[project.locationHash] = xd2!!
         connect(xd2)
       } else {
+        this.toolName = dialogConnectionFile?.bspConnectionDetails?.name
         bspUtilService.bspConnectionDetails[project.locationHash] = dialogConnectionFile!!
         connect(dialogConnectionFile!!)
       }

--- a/src/main/kotlin/org/jetbrains/plugins/bsp/ui/widgets/tool/window/utils/BspBuildTargetClassifier.kt
+++ b/src/main/kotlin/org/jetbrains/plugins/bsp/ui/widgets/tool/window/utils/BspBuildTargetClassifier.kt
@@ -1,0 +1,67 @@
+package org.jetbrains.plugins.bsp.ui.widgets.tool.window.utils
+
+import ch.epfl.scala.bsp4j.BuildTarget
+
+public interface BspBuildTargetClassifier {
+  /**
+   * @return name of the tool corresponding to this classifier
+   */
+  public fun name(): String
+
+  /**
+   * Sets a separator for chaining target directories. Example:
+   * ```
+   * aaa
+   *   | bbb
+   *   | ccc
+   *       | ddd
+   *           | eee
+   *               | BUILD_TARGET
+   * ```
+   * If the separator is set (for example to "+_"), the tree above will be rendered as:
+   * ```
+   * aaa
+   *   | bbb
+   *   | ccc+_ddd+_eee
+   *       | BUILD_TARGET
+   * ```
+   * This affects only directories with just one child, this child being another directory
+   */
+  public fun separator(): String? = null
+
+  /**
+   * @param buildTarget a build target
+   * @return list of directories corresponding to a desired path of the given build target in the tree.
+   * For example, path `["aaa", "bbb"]` will render as:
+   * ```
+   * aaa
+   *   | bbb
+   *       | <buildTarget>
+   * ```
+   * If an empty list is returned, the build target will be rendered in the tree's top level
+   */
+  public fun getBuildTargetPath(buildTarget: BuildTarget): List<String>
+
+  /**
+   * @param buildTarget - a build target
+   * @return the name under which the given build target will be rendered in the tree
+   */
+  public fun getBuildTargetName(buildTarget: BuildTarget): String = buildTarget.displayName
+}
+
+public class BspBuildTargetClassifierProvider(
+  private val toolName: String?,
+  private val bspBuildTargetClassifiers: List<BspBuildTargetClassifier>
+) {
+  private fun getExtensionOrNull(): BspBuildTargetClassifier? =
+    bspBuildTargetClassifiers.firstOrNull { it.name() == toolName }
+
+  public fun getSeparator(): String? =
+    getExtensionOrNull()?.separator()
+
+  public fun getBuildTargetPath(buildTarget: BuildTarget): List<String> =
+    getExtensionOrNull()?.getBuildTargetPath(buildTarget) ?: listOf()
+
+  public fun getBuildTargetName(buildTarget: BuildTarget): String =
+    getExtensionOrNull()?.getBuildTargetName(buildTarget) ?: buildTarget.displayName
+}

--- a/src/main/kotlin/org/jetbrains/plugins/bsp/ui/widgets/tool/window/utils/BspTargetTree.kt
+++ b/src/main/kotlin/org/jetbrains/plugins/bsp/ui/widgets/tool/window/utils/BspTargetTree.kt
@@ -1,0 +1,197 @@
+package org.jetbrains.plugins.bsp.ui.widgets.tool.window.utils
+
+import ch.epfl.scala.bsp4j.BuildTarget
+import com.intellij.ui.components.JBLabel
+import com.intellij.ui.treeStructure.Tree
+import com.intellij.util.PlatformIcons
+import org.jetbrains.plugins.bsp.extension.points.BspBuildTargetClassifierExtension
+import java.awt.Component
+import javax.swing.Icon
+import javax.swing.JTree
+import javax.swing.SwingConstants
+import javax.swing.tree.DefaultMutableTreeNode
+import javax.swing.tree.MutableTreeNode
+import javax.swing.tree.TreeCellRenderer
+import javax.swing.tree.TreeNode
+import javax.swing.tree.TreePath
+import javax.swing.tree.TreeSelectionModel
+
+private interface NodeData
+private data class DirectoryNodeData(val name: String) : NodeData
+private data class TargetNodeData(val target: BuildTarget, val displayName: String) : NodeData
+
+private data class BuildTargetTreeIdentifier(
+  val target: BuildTarget,
+  val path: List<String>,
+  val displayName: String
+)
+
+private class TargetTreeCellRenderer(val targetIcon: Icon) : TreeCellRenderer {
+  override fun getTreeCellRendererComponent(
+    tree: JTree?,
+    value: Any?,
+    selected: Boolean,
+    expanded: Boolean,
+    leaf: Boolean,
+    row: Int,
+    hasFocus: Boolean
+  ): Component {
+    return when (val userObject = (value as? DefaultMutableTreeNode)?.userObject) {
+      is DirectoryNodeData -> JBLabel(
+        userObject.name,
+        PlatformIcons.FOLDER_ICON,
+        SwingConstants.LEFT
+      )
+
+      is TargetNodeData -> JBLabel(
+        userObject.displayName,
+        targetIcon,
+        SwingConstants.LEFT
+      )
+
+      else -> JBLabel(
+        "[not renderable]",
+        PlatformIcons.ERROR_INTRODUCTION_ICON,
+        SwingConstants.LEFT
+      )  // TODO - temporary
+    }
+  }
+}
+
+/**
+ * Responsible for generating a build target tree
+ * @param targetIcon an icon for all build targets in the generated tree
+ */
+public class BspTargetTree(targetIcon: Icon) {
+  private val rootNode = DefaultMutableTreeNode(DirectoryNodeData("[root]"))
+
+  public val treeComponent: Tree = Tree(rootNode)
+
+  private val cellRenderer = TargetTreeCellRenderer(targetIcon)
+
+  init {
+    treeComponent.selectionModel.selectionMode = TreeSelectionModel.SINGLE_TREE_SELECTION
+    treeComponent.cellRenderer = cellRenderer
+    treeComponent.isRootVisible = false
+  }
+
+  /**
+   * Generates a tree of given build targets. The new tree replaces the previous one
+   * @param toolName name of the BspBuildTargetClassifierExtension used to assemble the tree. If null, all
+   * targets will be shown as a simple list
+   * @param targets build targets to be put into the tree
+   */
+  public fun generateTree(toolName: String?, targets: Collection<BuildTarget>) {
+    val bspBuildTargetClassifierProvider =
+      BspBuildTargetClassifierProvider(toolName, BspBuildTargetClassifierExtension.extensions())
+    generateTreeFromIdentifiers(
+      targets.map {
+        BuildTargetTreeIdentifier(
+          it,
+          bspBuildTargetClassifierProvider.getBuildTargetPath(it),
+          bspBuildTargetClassifierProvider.getBuildTargetName(it)
+        )
+      },
+      bspBuildTargetClassifierProvider.getSeparator()
+    )
+  }
+
+  /**
+   * Generates a tree using a list of BuildTargetTreeIdentifiers. The new tree replaces the previous one
+   * @param targets a list of BuildTargetTreeIdentifiers to be put into the tree
+   * @param separator separator to be used to chain directories
+   * @see BspBuildTargetClassifier.separator
+   */
+  private fun generateTreeFromIdentifiers(targets: List<BuildTargetTreeIdentifier>, separator: String?) {
+    val grouped: Map<String?, List<BuildTargetTreeIdentifier>> = targets.groupBy { it.path.firstOrNull() }
+    val sortedDirs: List<String> = grouped
+      .keys
+      .filterNotNull()
+      .sorted()
+    rootNode.removeAllChildren()
+    for (dir in sortedDirs) {
+      rootNode.add(generateDirectoryNode(grouped[dir]!!, dir, separator, 0))
+    }
+    if (grouped.containsKey(null)) {
+      for (identifier in grouped[null]!!) {
+        rootNode.add(generateTargetNode(identifier))
+      }
+    }
+
+    // Without the following line, target tree might not show (unexpanded root's children are invisible)
+    treeComponent.expandPath(TreePath(rootNode.path))
+  }
+
+  /**
+   * Recursively generates a directory node for the tree
+   * @param targets a list of BuildTargetTreeIdentifiers to be put in this directory
+   * @param dirname a name for this directory
+   * @param separator separator to be used to chain directories
+   * @param depth current recurrence depth
+   * @return the created directory node
+   * @see BspBuildTargetClassifier.separator
+   */
+  private fun generateDirectoryNode(
+    targets: List<BuildTargetTreeIdentifier>,
+    dirname: String,
+    separator: String?,
+    depth: Int
+  ): DefaultMutableTreeNode {
+    val node = DefaultMutableTreeNode()
+    val childrenList: MutableList<TreeNode> = mutableListOf()
+
+    node.userObject = DirectoryNodeData(dirname)
+    val grouped: Map<String?, List<BuildTargetTreeIdentifier>> = targets.groupBy { it.path.getOrNull(depth + 1) }
+    val sortedDirs: List<String> = grouped
+      .keys
+      .filterNotNull()
+      .sorted()
+    var index = 0
+    for (dir in sortedDirs) {
+      childrenList.add(generateDirectoryNode(grouped[dir]!!, dir, separator, depth + 1))
+    }
+    if (grouped.containsKey(null)) {
+      for (identifier in grouped[null]!!) {
+        childrenList.add(generateTargetNode(identifier))
+      }
+    }
+    if (separator != null && childrenList.size == 1) {
+      val child = childrenList.first() as? DefaultMutableTreeNode
+      val childObject = child?.userObject
+      if (childObject is DirectoryNodeData) {
+        node.userObject = DirectoryNodeData("${dirname}${separator}${childObject.name}")
+        childrenList.clear()
+        childrenList.addAll(child.children().toList())
+      }
+    }
+    for (child in childrenList) {
+      if (child is MutableTreeNode) {
+        node.insert(child, index++)
+      }
+    }
+    return node
+  }
+
+  /**
+   * Generates a node for a build target
+   * @param identifier build target this node will represent
+   * @return the created node
+   */
+  private fun generateTargetNode(identifier: BuildTargetTreeIdentifier): DefaultMutableTreeNode {
+    return DefaultMutableTreeNode(TargetNodeData(identifier.target, identifier.displayName))
+  }
+
+  public companion object {
+    /**
+     * @return build target represented by the node selected in the tree. Is null when nothing is selected
+     */
+    public fun getSelectedBspTarget(tree: Tree): BuildTarget? {
+      val selected: DefaultMutableTreeNode? = tree.lastSelectedPathComponent as? DefaultMutableTreeNode
+      val userObject: Any? = selected?.userObject
+      if (userObject is TargetNodeData) {
+        return userObject.target
+      }
+      return null
+    }
+  }
+}

--- a/src/main/kotlin/org/jetbrains/plugins/bsp/ui/widgets/tool/window/utils/LoadedTargetsMouseListener.kt
+++ b/src/main/kotlin/org/jetbrains/plugins/bsp/ui/widgets/tool/window/utils/LoadedTargetsMouseListener.kt
@@ -50,39 +50,37 @@ public class LoadedTargetsMouseListener(
   override fun mouseClicked(e: MouseEvent?): Unit = mouseClickedNotNull(e!!)
 
   private fun mouseClickedNotNull(mouseEvent: MouseEvent) {
-    updateSelectedIndex(mouseEvent)
-
     if (mouseEvent.mouseButton == MouseButton.Right) {
       showPopup(mouseEvent)
     }
   }
 
-  private fun updateSelectedIndex(mouseEvent: MouseEvent) {
-    listsUpdater.loadedTargetsJbList.selectedIndex =
-      listsUpdater.loadedTargetsJbList.locationToIndex(mouseEvent.point)
-  }
-
   private fun showPopup(mouseEvent: MouseEvent) {
     val actionGroup = calculatePopupGroup()
-    val context = DataManager.getInstance().getDataContext(mouseEvent.component)
-    val mnemonics = JBPopupFactory.ActionSelectionAid.MNEMONICS
+    if (actionGroup != null) {
+      val context = DataManager.getInstance().getDataContext(mouseEvent.component)
+      val mnemonics = JBPopupFactory.ActionSelectionAid.MNEMONICS
 
-    JBPopupFactory.getInstance()
-      .createActionGroupPopup(null, actionGroup, context, mnemonics, true)
-      .showInBestPositionFor(context)
+      JBPopupFactory.getInstance()
+        .createActionGroupPopup(null, actionGroup, context, mnemonics, true)
+        .showInBestPositionFor(context)
+    }
   }
 
-  private fun calculatePopupGroup(): ActionGroup {
-    val group = DefaultActionGroup()
+  private fun calculatePopupGroup(): ActionGroup? {
+    val target: BuildTargetIdentifier? = BspTargetTree.getSelectedBspTarget(listsUpdater.loadedTargetsTreeComponent)?.id
 
-    val target = listsUpdater.loadedTargetsJbList.selectedValue.id
-    val action = BuildTargetAction(
-      BspAllTargetsWidgetBundle.message("widget.build.target.popup.message"),
-      target
-    )
-    group.addAction(action)
+    if (target != null) {
+      val group = DefaultActionGroup()
+      val action = BuildTargetAction(
+        BspAllTargetsWidgetBundle.message("widget.build.target.popup.message"),
+        target
+      )
+      group.addAction(action)
+      return group
+    }
 
-    return group
+    return null
   }
 
   override fun mousePressed(e: MouseEvent?) { }

--- a/src/main/kotlin/org/jetbrains/plugins/bsp/ui/widgets/tool/window/utils/NotLoadedTargetsMouseListener.kt
+++ b/src/main/kotlin/org/jetbrains/plugins/bsp/ui/widgets/tool/window/utils/NotLoadedTargetsMouseListener.kt
@@ -28,24 +28,13 @@ private class LoadTargetAction(
   }
 }
 
-public class NotLoadedTargetsListMouseListener(
+public class NotLoadedTargetsMouseListener(
   private val listsUpdater: ListsUpdater,
 ) : MouseListener {
 
   override fun mouseClicked(e: MouseEvent?): Unit = mouseClickedNotNull(e!!)
 
   private fun mouseClickedNotNull(mouseEvent: MouseEvent) {
-    updateSelectedIndex(mouseEvent)
-
-    showPopupIfRightButtonClicked(mouseEvent)
-  }
-
-  private fun updateSelectedIndex(mouseEvent: MouseEvent) {
-    listsUpdater.notLoadedTargetsJbList.selectedIndex =
-      listsUpdater.notLoadedTargetsJbList.locationToIndex(mouseEvent.point)
-  }
-
-  private fun showPopupIfRightButtonClicked(mouseEvent: MouseEvent) {
     if (mouseEvent.mouseButton == MouseButton.Right) {
       showPopup(mouseEvent)
     }
@@ -53,33 +42,38 @@ public class NotLoadedTargetsListMouseListener(
 
   private fun showPopup(mouseEvent: MouseEvent) {
     val actionGroup = calculatePopupGroup()
-    val context = DataManager.getInstance().getDataContext(mouseEvent.component)
-    val mnemonics = JBPopupFactory.ActionSelectionAid.MNEMONICS
+    if (actionGroup != null) {
+      val context = DataManager.getInstance().getDataContext(mouseEvent.component)
+      val mnemonics = JBPopupFactory.ActionSelectionAid.MNEMONICS
 
-    JBPopupFactory.getInstance()
-      .createActionGroupPopup(null, actionGroup, context, mnemonics, true)
-      .showInBestPositionFor(context)
+      JBPopupFactory.getInstance()
+        .createActionGroupPopup(null, actionGroup, context, mnemonics, true)
+        .showInBestPositionFor(context)
+    }
   }
 
-  private fun calculatePopupGroup(): ActionGroup {
-    val group = DefaultActionGroup()
+  private fun calculatePopupGroup(): ActionGroup? {
+    val target: BuildTargetIdentifier? =
+      BspTargetTree.getSelectedBspTarget(listsUpdater.notLoadedTargetsTreeComponent)?.id
 
-    val target = listsUpdater.notLoadedTargetsJbList.selectedValue.id
-    val action = LoadTargetAction(
-      BspAllTargetsWidgetBundle.message("widget.load.target.popup.message"),
-      target,
-      listsUpdater
-    )
-    group.addAction(action)
-
-    return group
+    if (target != null) {
+      val group = DefaultActionGroup()
+      val action = LoadTargetAction(
+        BspAllTargetsWidgetBundle.message("widget.load.target.popup.message"),
+        target,
+        listsUpdater
+      )
+      group.addAction(action)
+      return group
+    }
+    return null
   }
 
-  override fun mousePressed(e: MouseEvent?) { }
+  override fun mousePressed(e: MouseEvent?) {}
 
-  override fun mouseReleased(e: MouseEvent?) { }
+  override fun mouseReleased(e: MouseEvent?) {}
 
-  override fun mouseEntered(e: MouseEvent?) { }
+  override fun mouseEntered(e: MouseEvent?) {}
 
-  override fun mouseExited(e: MouseEvent?) { }
+  override fun mouseExited(e: MouseEvent?) {}
 }

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -9,10 +9,17 @@
     <extensionPoint qualifiedName="com.intellij.bspConnectionDetailsGeneratorExtension"
                     interface="org.jetbrains.plugins.bsp.extension.points.BspConnectionDetailsGeneratorExtension"
                     dynamic="true"/>
+    <extensionPoint qualifiedName="com.intellij.bspBuildTargetClassifierExtension"
+                    interface="org.jetbrains.plugins.bsp.extension.points.BspBuildTargetClassifierExtension"
+                    dynamic="true"/>
   </extensionPoints>
   <extensions defaultExtensionNs="com.intellij">
     <bspConnectionDetailsGeneratorExtension
       implementation="org.jetbrains.plugins.bsp.extension.points.TemporarySbtBspConnectionDetailsGenerator"
+    />
+
+    <bspBuildTargetClassifierExtension
+      implementation="org.jetbrains.plugins.bsp.extension.points.TemporaryTestTargetClassifier"
     />
 
     <projectOpenProcessor


### PR DESCRIPTION
BSP build targets are now displayed as a tree instead of a list. Added a new extension point responsible for generating paths for the build targets