### PR TITLE
[widget] add target search capability

### DIFF
--- a/src/main/kotlin/org/jetbrains/plugins/bsp/ui/widgets/tool/window/utils/LoadedTargetsMouseListener.kt
+++ b/src/main/kotlin/org/jetbrains/plugins/bsp/ui/widgets/tool/window/utils/LoadedTargetsMouseListener.kt
@@ -12,13 +12,13 @@ import com.intellij.openapi.progress.runBackgroundableTask
 import com.intellij.openapi.ui.popup.JBPopupFactory
 import com.intellij.project.stateStore
 import org.jetbrains.plugins.bsp.services.BspConnectionService
-import org.jetbrains.plugins.bsp.ui.widgets.tool.window.ListsUpdater
 import org.jetbrains.plugins.bsp.ui.widgets.tool.window.all.targets.BspAllTargetsWidgetBundle
 import java.awt.event.MouseEvent
 import java.awt.event.MouseListener
 import org.jetbrains.plugins.bsp.services.BspBuildConsoleService
 import org.jetbrains.plugins.bsp.services.BspSyncConsoleService
 import org.jetbrains.plugins.bsp.services.VeryTemporaryBspResolver
+import javax.swing.JComponent
 
 private class BuildTargetAction(
   text: String,
@@ -44,7 +44,8 @@ private class BuildTargetAction(
 }
 
 public class LoadedTargetsMouseListener(
-  private val listsUpdater: ListsUpdater,
+//  private val listsUpdater: ListsUpdater,
+  private val component: JComponent
 ) : MouseListener {
 
   override fun mouseClicked(e: MouseEvent?): Unit = mouseClickedNotNull(e!!)
@@ -68,7 +69,7 @@ public class LoadedTargetsMouseListener(
   }
 
   private fun calculatePopupGroup(): ActionGroup? {
-    val target: BuildTargetIdentifier? = BspTargetTree.getSelectedBspTarget(listsUpdater.loadedTargetsTreeComponent)?.id
+    val target: BuildTargetIdentifier? = BspTargetTree.getSelectedBspTarget(component)?.id
 
     if (target != null) {
       val group = DefaultActionGroup()

--- a/src/main/kotlin/org/jetbrains/plugins/bsp/ui/widgets/tool/window/utils/NotLoadedTargetsMouseListener.kt
+++ b/src/main/kotlin/org/jetbrains/plugins/bsp/ui/widgets/tool/window/utils/NotLoadedTargetsMouseListener.kt
@@ -14,6 +14,7 @@ import org.jetbrains.plugins.bsp.ui.widgets.tool.window.ListsUpdater
 import org.jetbrains.plugins.bsp.ui.widgets.tool.window.all.targets.BspAllTargetsWidgetBundle
 import java.awt.event.MouseEvent
 import java.awt.event.MouseListener
+import javax.swing.JComponent
 
 private class LoadTargetAction(
   text: String,
@@ -30,6 +31,7 @@ private class LoadTargetAction(
 
 public class NotLoadedTargetsMouseListener(
   private val listsUpdater: ListsUpdater,
+  private val component: JComponent
 ) : MouseListener {
 
   override fun mouseClicked(e: MouseEvent?): Unit = mouseClickedNotNull(e!!)
@@ -54,7 +56,7 @@ public class NotLoadedTargetsMouseListener(
 
   private fun calculatePopupGroup(): ActionGroup? {
     val target: BuildTargetIdentifier? =
-      BspTargetTree.getSelectedBspTarget(listsUpdater.notLoadedTargetsTreeComponent)?.id
+      BspTargetTree.getSelectedBspTarget(component)?.id
 
     if (target != null) {
       val group = DefaultActionGroup()

--- a/src/main/kotlin/org/jetbrains/plugins/bsp/ui/widgets/tool/window/utils/TargetSearch.kt
+++ b/src/main/kotlin/org/jetbrains/plugins/bsp/ui/widgets/tool/window/utils/TargetSearch.kt
@@ -1,0 +1,85 @@
+package org.jetbrains.plugins.bsp.ui.widgets.tool.window.utils
+
+import ch.epfl.scala.bsp4j.BuildTarget
+import com.intellij.ui.components.JBLabel
+import com.intellij.ui.components.JBList
+import com.intellij.ui.components.JBTextField
+import javax.swing.DefaultListModel
+import javax.swing.Icon
+import javax.swing.ListSelectionModel
+import javax.swing.SwingConstants
+import javax.swing.event.DocumentEvent
+import javax.swing.event.DocumentListener
+
+private class TextChangeListener(val onUpdate: () -> Unit): DocumentListener {
+  override fun insertUpdate(e: DocumentEvent?) {
+    onUpdate()
+  }
+
+  override fun removeUpdate(e: DocumentEvent?) {
+    onUpdate()
+  }
+
+  override fun changedUpdate(e: DocumentEvent?) {
+    onUpdate()
+  }
+}
+
+public class TargetSearch(private val targetIcon: Icon, private val onUpdate: () -> Unit) {
+  public var targets: Collection<BuildTarget> = emptyList()
+  public var searchActive: Boolean = false
+    private set
+
+  public val searchBarComponent: JBTextField = JBTextField()
+  private val searchListModel = DefaultListModel<BuildTarget>()
+  public val searchListComponent: JBList<BuildTarget> = JBList(searchListModel)
+
+  init {
+    searchBarComponent.document.addDocumentListener(TextChangeListener(this::updateSearch))
+    searchListComponent.selectionMode = ListSelectionModel.SINGLE_SELECTION
+    searchListComponent.installCellRenderer {
+      JBLabel(
+        emphasizeQuery(it.displayName ?: it.id.uri),
+        targetIcon,
+        SwingConstants.LEFT
+      )
+    }
+  }
+
+  /**
+   * Filters the build targets based on current search query. This method is executed each time
+   * the search query is modified
+   */
+  private fun updateSearch() {
+    val query = searchBarComponent.text
+    this.searchActive = query.isNotEmpty()
+    searchListModel.removeAllElements()
+    onUpdate()
+    if (searchActive) {
+      searchListModel.addAll(targets.filter { (it.displayName ?: it.id.uri).contains(query, true) })
+      searchListComponent.revalidate()
+    }
+  }
+
+  /**
+   * Emphasises text's name fragments containing search query
+   * @param text the text to be processed
+   * @return the text, wrapped in `<html>` tags, with all search query occurrences bolded and underlined
+   */
+  private fun emphasizeQuery(text: String): String {
+    val query = searchBarComponent.text
+    return "<html>${emphasizeQuery(text, "", query, 0)}</html>"
+  }
+
+  private tailrec fun emphasizeQuery(text: String, builtText: String, query: String, startIndex: Int): String {
+    val foundIndex = text.indexOf(query, startIndex, true)
+    if (foundIndex < 0) {
+      return builtText + text.substring(startIndex)
+    }
+    val endFoundIndex = foundIndex + query.length
+    val updatedText = builtText +
+      text.substring(startIndex, foundIndex) +
+      "<b><u>${text.substring(foundIndex, endFoundIndex)}</u></b>"
+    return emphasizeQuery(text, updatedText, query, endFoundIndex)
+  }
+}


### PR DESCRIPTION
Build target tree now have a search bar. Entering text into it changes targets display into a list of targets matching the search query. Clearing the search bar changes the display back to a normal tree