### PR TITLE
[fix] timeout for javacOptions and small stability improvements

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -28,6 +28,10 @@ dependencies {
   testImplementation("io.kotest:kotest-assertions-core:5.5.2")
 }
 
+tasks.runIde{
+  jvmArgs("-Xmx8000m")
+}
+
 // Configure gradle-intellij-plugin plugin.
 // Read more: https://github.com/JetBrains/gradle-intellij-plugin
 intellij {

--- a/magicmetamodel/src/main/kotlin/org/jetbrains/magicmetamodel/impl/NonOverlappingTargets.kt
+++ b/magicmetamodel/src/main/kotlin/org/jetbrains/magicmetamodel/impl/NonOverlappingTargets.kt
@@ -40,8 +40,7 @@ internal object NonOverlappingTargets {
   ): Set<BuildTargetIdentifier> {
     val nonOverlappingTargetsAccWithTarget =
       addTargetToSetIfNoneOfItsNeighborsIsAdded(nonOverlappingTargetsAcc, target, overlappingTargetsGraph)
-
-    return target.dependencies
+    return (target.dependencies - nonOverlappingTargetsAccWithTarget)
       .mapNotNull { mapTargetIdToTarget(allTargets, it) }
       .fold(nonOverlappingTargetsAccWithTarget) { acc, targetToAdd ->
         addTargetToSetIfNoneOfItsNeighborsIsAddedAndDoTheSameForDependencies(

--- a/magicmetamodel/src/test/kotlin/org/jetbrains/magicmetamodel/impl/NonOverlappingTargetsTest.kt
+++ b/magicmetamodel/src/test/kotlin/org/jetbrains/magicmetamodel/impl/NonOverlappingTargetsTest.kt
@@ -231,4 +231,23 @@ class NonOverlappingTargetsTest {
     )
     nonOverlappingTargets shouldContainExactlyInAnyOrder expectedTargets
   }
+
+  @Test
+  fun cycleInGraph() {
+    val targetA = BuildTarget(
+      id = BuildTargetId("targetA"),
+      dependencies = listOf(BuildTargetId("targetB"))
+    )
+
+    val targetB = BuildTarget(
+      id = BuildTargetId("targetB"),
+      dependencies = listOf(BuildTargetId("targetA"))
+    )
+
+    val allTargets = setOf(targetA, targetB)
+
+    val nonOverlappingTargets = NonOverlappingTargets(allTargets, overlappingTargetsGraph = mapOf())
+    val expectedTargets = setOf(BuildTargetId("targetA"), BuildTargetId("targetB"))
+    nonOverlappingTargets shouldContainExactlyInAnyOrder expectedTargets
+  }
 }

--- a/src/main/kotlin/org/jetbrains/plugins/bsp/server/connection/BspFileConnection.kt
+++ b/src/main/kotlin/org/jetbrains/plugins/bsp/server/connection/BspFileConnection.kt
@@ -70,6 +70,7 @@ public class BspFileConnection(
     ProcessBuilder(bspConnectionDetails.argv)
       .directory(project.stateStore.projectBasePath.toFile())
       .withRealEnvs()
+      .redirectError(ProcessBuilder.Redirect.INHERIT)
       .start()
 
   private fun createBspClient(): BspClient {


### PR DESCRIPTION
1. Add timeout to javacOptions request, as SBT hangs in case it's called

2. addTargetToSetIfNoneOfItsNeighborsIsAddedAndDoTheSameForDependencies method is recursive, but it was terminated only when target.dependencies was an empty list, as this is only case when `fold`'s inner method (the `addTarget...Dependencies` method itself). In case when dependency graph is not acyclic, this will be called infinitely, that's why we need to care we don't process graph's nodes twice. That's why we skip the ones that has already been added to `nonOverlappingTargetsGraph`.

3. inherit stderr from bsp process, just to make sure it does not hang if buffer is full
