### PR TITLE
Defer mytoken requirement until runtime

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -114,7 +114,7 @@ tasks {
 
   publishPlugin {
     dependsOn("patchChangelog")
-    token.set(myToken)
+    token.set(provider { myToken })
     // pluginVersion is based on the SemVer (https://semver.org) and supports pre-release labels, like 2.1.7-alpha.3
     // Specify pre-release label to publish the plugin in a custom Release Channel automatically. Read more:
     // https://plugins.jetbrains.com/docs/intellij/deployment.html#specifying-a-release-channel


### PR DESCRIPTION
Prevents gradle init failing when token is not provided