### PR TITLE
Use java 17 toolchain

### DIFF
--- a/buildSrc/src/main/kotlin/intellijbsp.kotlin-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/intellijbsp.kotlin-conventions.gradle.kts
@@ -17,6 +17,9 @@ repositories {
 
 kotlin {
   explicitApi()
+  jvmToolchain {
+    languageVersion = JavaLanguageVersion.of(javaVersion)
+  }
 }
 
 // Configure detekt plugin.


### PR DESCRIPTION
Project is using java 17 APIs, add explicit `jvmToolchain` call to compile with java 17.