### PR TITLE
Add compose reimplementation of toolwindow with the use of Jewel library

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,6 +1,9 @@
 [versions]
 detekt = "1.23.4"
 kotlin-gradle-version = "1.9.20"
+composeDesktop = "1.5.11"
+jewel = "0.11.0-ij-233"
+
 
 [libraries]
 junitJupiter = { module = "org.junit.jupiter:junit-jupiter", version = "5.10.1" }
@@ -11,7 +14,11 @@ gson = { module = "com.google.code.gson:gson", version = "2.10.1" }
 detektFormatting = { module = "io.gitlab.arturbosch.detekt:detekt-formatting", version.ref = "detekt" }
 detektGradle = { module = "io.gitlab.arturbosch.detekt:detekt-gradle-plugin", version.ref = "detekt" }
 kotlinGradle = { module = "org.jetbrains.kotlin:kotlin-gradle-plugin", version.ref = "kotlin-gradle-version" }
+coursier = { module = "io.get-coursier:coursier_2.13", version = "2.1.5" }
+jewelIdeLafBridge = {module = "org.jetbrains.jewel:jewel-ide-laf-bridge", version.ref = "jewel" }
 
 [plugins]
 intellij = { id = "org.jetbrains.intellij", version = "1.16.0" }
 changelog = { id = "org.jetbrains.changelog", version = "2.2.0" }
+composeDesktop = { id = "org.jetbrains.compose", version.ref = "composeDesktop" }
+shadow = { id = "com.github.johnrengelman.shadow", version = "8.1.1" }

--- a/src/main/kotlin/org/jetbrains/plugins/bsp/assets/BspAssetsExtension.kt
+++ b/src/main/kotlin/org/jetbrains/plugins/bsp/assets/BspAssetsExtension.kt
@@ -1,7 +1,6 @@
 package org.jetbrains.plugins.bsp.assets
 
 import com.intellij.icons.AllIcons
-import com.intellij.openapi.util.IconLoader
 import org.jetbrains.plugins.bsp.config.BspPluginIcons
 import org.jetbrains.plugins.bsp.extension.points.BuildToolId
 import org.jetbrains.plugins.bsp.extension.points.bspBuildToolId
@@ -14,8 +13,8 @@ public class BspAssetsExtension : BuildToolAssetsExtension {
 
   override val icon: Icon = BspPluginIcons.bsp
 
-  override val loadedTargetIcon: Icon = BspPluginIcons.bsp
-  override val unloadedTargetIcon: Icon = IconLoader.getIcon("/icons/notLoaded.svg", javaClass)
+  override val loadedTargetIcon: AssetIcon = AssetIcon("icons/bsp.svg", BspPluginIcons::class.java)
+  override val unloadedTargetIcon: AssetIcon = AssetIcon("icons/notLoaded.svg", BspPluginIcons::class.java)
 
-  override val invalidTargetIcon: Icon = AllIcons.General.Warning
+  override val invalidTargetIcon: AssetIcon = AssetIcon("general/warning.svg", AllIcons::class.java)
 }

--- a/src/main/kotlin/org/jetbrains/plugins/bsp/assets/BuildToolAssetsExtension.kt
+++ b/src/main/kotlin/org/jetbrains/plugins/bsp/assets/BuildToolAssetsExtension.kt
@@ -9,13 +9,19 @@ public interface BuildToolAssetsExtension : WithBuildToolId {
 
   public val icon: Icon
 
-  public val loadedTargetIcon: Icon
-  public val unloadedTargetIcon: Icon
+  // In Swing toolwindow implementation instead of `AssetIcon`, `javax.swing.Icon` is used
+  public val loadedTargetIcon: AssetIcon
+  public val unloadedTargetIcon: AssetIcon
 
-  public val invalidTargetIcon: Icon
+  public val invalidTargetIcon: AssetIcon
 
   public companion object {
     internal val ep =
       ExtensionPointName.create<BuildToolAssetsExtension>("org.jetbrains.bsp.buildToolAssetsExtension")
   }
 }
+
+public data class AssetIcon(
+  public val path: String,
+  public val clazz: Class<out Any>,
+)

--- a/src/main/kotlin/org/jetbrains/plugins/bsp/flow/open/BspStartupActivity.kt
+++ b/src/main/kotlin/org/jetbrains/plugins/bsp/flow/open/BspStartupActivity.kt
@@ -21,6 +21,7 @@ import org.jetbrains.plugins.bsp.config.isBspProject
 import org.jetbrains.plugins.bsp.config.rootDir
 import org.jetbrains.plugins.bsp.extension.points.BuildToolId
 import org.jetbrains.plugins.bsp.extension.points.withBuildToolIdOrDefault
+import org.jetbrains.plugins.bsp.jewel.ui.registerBspJewelToolWindow
 import org.jetbrains.plugins.bsp.server.connection.ConnectionDetailsProviderExtension
 import org.jetbrains.plugins.bsp.server.connection.DefaultBspConnection
 import org.jetbrains.plugins.bsp.server.connection.connection
@@ -69,6 +70,7 @@ public class BspStartupActivity : ProjectActivity {
 
   private suspend fun Project.executeEveryTime() {
     registerBspToolWindow(this)
+    registerBspJewelToolWindow(this)
     RunConfigurationProducersDisabler(this)
   }
 

--- a/src/main/kotlin/org/jetbrains/plugins/bsp/jewel/ui/BspJewelToolWindowFactory.kt
+++ b/src/main/kotlin/org/jetbrains/plugins/bsp/jewel/ui/BspJewelToolWindowFactory.kt
@@ -1,0 +1,64 @@
+package org.jetbrains.plugins.bsp.jewel.ui
+
+import androidx.compose.runtime.Composable
+import com.intellij.openapi.application.EDT
+import com.intellij.openapi.project.DumbAware
+import com.intellij.openapi.project.Project
+import com.intellij.openapi.wm.ToolWindow
+import com.intellij.openapi.wm.ToolWindowAnchor
+import com.intellij.openapi.wm.ToolWindowFactory
+import com.intellij.openapi.wm.ToolWindowManager
+import com.intellij.ui.content.ContentFactory
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.withContext
+import org.jetbrains.jewel.bridge.JewelComposePanel
+import org.jetbrains.jewel.bridge.ToolWindowScope
+import org.jetbrains.plugins.bsp.assets.BuildToolAssetsExtension
+import org.jetbrains.plugins.bsp.config.buildToolId
+import org.jetbrains.plugins.bsp.config.isBspProject
+import org.jetbrains.plugins.bsp.extension.points.withBuildToolIdOrDefault
+
+@ExperimentalCoroutinesApi
+internal class BspJewelToolWindowFactory : ToolWindowFactory, DumbAware {
+  override suspend fun isApplicableAsync(project: Project): Boolean = project.isBspProject
+  override fun shouldBeAvailable(project: Project): Boolean =
+    project.isBspProject
+
+  override fun createToolWindowContent(project: Project, toolWindow: ToolWindow) {
+    toolWindow.createToolWindowPanel {
+      ToolWindowPanelContent(project).render()
+    }
+  }
+}
+
+private fun ToolWindow.createToolWindowPanel(content: @Composable ToolWindowScope.() -> Unit) {
+  contentManager.removeAllContents(true)
+
+  val panel = JewelComposePanel {
+    val scope = object : ToolWindowScope {
+      override val toolWindow: ToolWindow
+        get() = this@createToolWindowPanel
+    }
+    scope.content()
+  }
+  contentManager.addContent(ContentFactory.getInstance().createContent(panel, "", false))
+  this.show()
+}
+
+@OptIn(ExperimentalCoroutinesApi::class)
+public suspend fun registerBspJewelToolWindow(project: Project) {
+  val toolWindowManager = ToolWindowManager.getInstance(project)
+  val assetsExtension = BuildToolAssetsExtension.ep.withBuildToolIdOrDefault(project.buildToolId)
+  val currentToolWindow = toolWindowManager.getToolWindow(assetsExtension.presentableName + "-Jewel")
+  if (currentToolWindow == null) {
+    withContext(Dispatchers.EDT) {
+      toolWindowManager.registerToolWindow(assetsExtension.presentableName + "-Jewel") {
+        this.icon = assetsExtension.icon
+        this.anchor = ToolWindowAnchor.RIGHT
+        this.canCloseContent = false
+        this.contentFactory = BspJewelToolWindowFactory()
+      }
+    }
+  }
+}

--- a/src/main/kotlin/org/jetbrains/plugins/bsp/jewel/ui/ComposableToolbar.kt
+++ b/src/main/kotlin/org/jetbrains/plugins/bsp/jewel/ui/ComposableToolbar.kt
@@ -1,0 +1,184 @@
+package org.jetbrains.plugins.bsp.jewel.ui
+
+import androidx.compose.foundation.ExperimentalFoundationApi
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.RowScope
+import androidx.compose.foundation.layout.fillMaxHeight
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.Divider
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import com.intellij.icons.AllIcons
+import org.jetbrains.jewel.bridge.LocalComponent
+import org.jetbrains.jewel.foundation.ExperimentalJewelApi
+import org.jetbrains.jewel.foundation.modifier.trackComponentActivation
+import org.jetbrains.jewel.foundation.theme.JewelTheme
+import org.jetbrains.jewel.ui.component.Icon
+import org.jetbrains.jewel.ui.component.IconButton
+import org.jetbrains.jewel.ui.component.Text
+import org.jetbrains.jewel.ui.component.Tooltip
+import org.jetbrains.jewel.ui.theme.iconButtonStyle
+import org.jetbrains.jewel.ui.util.thenIf
+import org.jetbrains.plugins.bsp.config.BspPluginBundle
+import org.jetbrains.plugins.bsp.config.BspPluginIcons
+
+internal class ComposableToolbar(
+  var panelState: ToolbarTab,
+  val setPanelState: (ToolbarTab) -> Unit,
+) {
+  // predefined values to match the design of the toolbar created with Swing
+  private val toolbarHeight = 19.dp
+  private val componentsDistance = 8.dp
+  private val buttonsDistance = 10.dp
+  private val dividerThickness = 1.dp
+  private val verticalDividerHeight = 32.dp
+  private val iconButtonBoxSize = 16.dp
+
+  @Composable
+  private fun horizontalDivider() {
+    Divider(modifier = Modifier.height(dividerThickness).fillMaxWidth())
+  }
+
+  @Composable
+  private fun verticalDivider() {
+    Divider(modifier = Modifier.height(verticalDividerHeight).width(dividerThickness))
+  }
+
+  @OptIn(ExperimentalFoundationApi::class)
+  @Composable
+  private fun wrapWithTooltipInBox(tooltipText: String, content: @Composable () -> Unit) {
+    Box(
+      modifier = Modifier.size(iconButtonBoxSize),
+    ) {
+      Tooltip(tooltip = {
+        Text(tooltipText)
+      }) {
+        content()
+      }
+    }
+  }
+
+  @Composable
+  private fun actionButtonWithTooltip(tooltipText: String, iconPath: String, onClick: () -> Unit) {
+    wrapWithTooltipInBox(tooltipText) {
+      IconButton(
+        onClick = onClick,
+        modifier = Modifier.fillMaxSize()
+      ) {
+        Icon(
+          resource = iconPath,
+          iconClass = BspPluginIcons::class.java,
+          contentDescription = null,
+        )
+      }
+    }
+  }
+
+  @Composable
+  private fun RowScope.targetsTabButton(
+    tooltipText: String,
+    iconPath: String,
+    isSelected: () -> Boolean,
+    onClick: () -> Unit,
+  ) {
+    wrapWithTooltipInBox(tooltipText) {
+      IconButton(
+        onClick = onClick,
+        modifier = Modifier.fillMaxSize()
+          .thenIf(isSelected()) {
+            background(
+              color = JewelTheme.iconButtonStyle.colors.backgroundPressed,
+              shape = RoundedCornerShape(JewelTheme.iconButtonStyle.metrics.cornerSize),
+            ).border(
+              width = JewelTheme.iconButtonStyle.metrics.borderWidth,
+              color = JewelTheme.iconButtonStyle.colors.backgroundPressed,
+              shape = RoundedCornerShape(JewelTheme.iconButtonStyle.metrics.cornerSize),
+            )
+          }
+      ) {
+        Icon(
+          resource = iconPath,
+          iconClass = BspPluginIcons::class.java,
+          contentDescription = null,
+        )
+      }
+    }
+  }
+
+  @OptIn(ExperimentalJewelApi::class)
+  @Composable
+  private fun RowScope.buttonsRow(buttons: @Composable RowScope.() -> Unit) {
+    Row(
+      modifier = Modifier.trackComponentActivation(LocalComponent.current)
+        .fillMaxHeight(),
+      horizontalArrangement = Arrangement.spacedBy(buttonsDistance),
+      verticalAlignment = Alignment.CenterVertically,
+    ) {
+      buttons()
+    }
+  }
+
+  @Composable
+  private fun RowScope.actionsRow() {
+    buttonsRow {
+      actionButtonWithTooltip(BspPluginBundle.message("connect.action.text"), "icons/connect.svg") {}
+      actionButtonWithTooltip(BspPluginBundle.message("reload.action.text"), "icons/reload.svg") {}
+      actionButtonWithTooltip(BspPluginBundle.message("build.and.resync.action.text"), "icons/buildAndResync.svg") {}
+      actionButtonWithTooltip(BspPluginBundle.message("disconnect.action.text"), "icons/disconnect.svg") {}
+    }
+  }
+
+  @Composable
+  private fun RowScope.targetsTabsRow() {
+    buttonsRow {
+      targetsTabButton(
+        tooltipText = BspPluginBundle.message("widget.not.loaded.targets.tab.name"),
+        iconPath = "icons/notLoaded.svg",
+        isSelected = { panelState == ToolbarTab.NOT_LOADED_TARGETS },
+        onClick = { setPanelState(ToolbarTab.NOT_LOADED_TARGETS) }
+      )
+      targetsTabButton(
+        tooltipText = BspPluginBundle.message("widget.loaded.targets.tab.name"),
+        iconPath = "icons/loaded.svg",
+        isSelected = { panelState == ToolbarTab.LOADED_TARGETS },
+        onClick = { setPanelState(ToolbarTab.LOADED_TARGETS) }
+      )
+    }
+  }
+
+  @OptIn(ExperimentalJewelApi::class)
+  @Composable
+  internal fun render() {
+    horizontalDivider()
+    Row(
+      modifier = Modifier.trackComponentActivation(LocalComponent.current)
+        .height(toolbarHeight)
+        .padding(start = componentsDistance, end = componentsDistance),
+      horizontalArrangement = Arrangement.spacedBy(componentsDistance),
+      verticalAlignment = Alignment.CenterVertically,
+    ) {
+      actionsRow()
+      verticalDivider()
+      targetsTabsRow()
+      verticalDivider()
+      Icon(
+        "general/filter.svg",
+        iconClass = AllIcons::class.java,
+        contentDescription = "An icon",
+      )
+    }
+    horizontalDivider()
+  }
+}

--- a/src/main/kotlin/org/jetbrains/plugins/bsp/jewel/ui/SwingToolbar.kt
+++ b/src/main/kotlin/org/jetbrains/plugins/bsp/jewel/ui/SwingToolbar.kt
@@ -1,0 +1,67 @@
+package org.jetbrains.plugins.bsp.jewel.ui
+
+import com.intellij.icons.AllIcons
+import com.intellij.openapi.actionSystem.ActionManager
+import com.intellij.openapi.actionSystem.ActionToolbar
+import com.intellij.openapi.actionSystem.AnAction
+import com.intellij.openapi.actionSystem.AnActionEvent
+import com.intellij.openapi.actionSystem.DefaultActionGroup
+import org.jetbrains.plugins.bsp.config.BspPluginBundle
+import org.jetbrains.plugins.bsp.config.BspPluginIcons
+import org.jetbrains.plugins.bsp.ui.widgets.tool.window.all.targets.StickyTargetAction
+
+// `CURRENTLY UNUSED`
+// Almost the same as in the Swing implementation of the UI
+internal fun swingToolbar(
+  panelState: ToolbarTab,
+  setPanelState: (ToolbarTab) -> Unit,
+): ActionToolbar {
+  val actionManager = ActionManager.getInstance()
+  val actionGroup = actionManager
+    .getAction("Bsp.ActionsToolbar") as DefaultActionGroup
+
+  val notLoadedTargetsActionName = BspPluginBundle.message("widget.not.loaded.targets.tab.name")
+  val loadedTargetsActionName = BspPluginBundle.message("widget.loaded.targets.tab.name")
+
+  actionGroup.childActionsOrStubs.iterator().forEach {
+    if (it.shouldBeDisposedAfterReload()) {
+      actionGroup.remove(it)
+    }
+  }
+  actionGroup.addSeparator()
+  actionGroup.add(StickyTargetAction(
+    hintText = notLoadedTargetsActionName,
+    icon = BspPluginIcons.unloadedTargetsFilterIcon,
+    onPerform = { setPanelState(ToolbarTab.NOT_LOADED_TARGETS) },
+    selectionProvider = { panelState == ToolbarTab.NOT_LOADED_TARGETS },
+  ))
+  actionGroup.add(StickyTargetAction(
+    hintText = loadedTargetsActionName,
+    icon = BspPluginIcons.loadedTargetsFilterIcon,
+    onPerform = { setPanelState(ToolbarTab.LOADED_TARGETS) },
+    selectionProvider = { panelState == ToolbarTab.LOADED_TARGETS },
+  ))
+
+  actionGroup.addSeparator()
+
+  // Filtering not implemented and therefore just icon is added:
+//  actionGroup.add(FilterActionGroup(listsUpdater.targetFilter))
+  actionGroup.add(DummyFilterAction())
+
+  return actionManager.createActionToolbar("Bsp Toolbar", actionGroup, true)
+}
+
+private fun AnAction.shouldBeDisposedAfterReload(): Boolean {
+  val notLoadedTargetsActionName = BspPluginBundle.message("widget.not.loaded.targets.tab.name")
+  val loadedTargetsActionName = BspPluginBundle.message("widget.loaded.targets.tab.name")
+  val filterAction = BspPluginBundle.message("widget.filter.action.group")
+  return this.templateText == notLoadedTargetsActionName ||
+    this.templateText == loadedTargetsActionName || this.templateText == filterAction
+}
+
+private class DummyFilterAction : AnAction(
+  { BspPluginBundle.message("widget.filter.action.group") },
+  AllIcons.General.Filter
+) {
+  override fun actionPerformed(e: AnActionEvent) {}
+}

--- a/src/main/kotlin/org/jetbrains/plugins/bsp/jewel/ui/ToolWindowPanelContent.kt
+++ b/src/main/kotlin/org/jetbrains/plugins/bsp/jewel/ui/ToolWindowPanelContent.kt
@@ -1,0 +1,139 @@
+package org.jetbrains.plugins.bsp.jewel.ui
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.ColumnScope
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import com.intellij.openapi.project.Project
+import com.intellij.ui.JBColor
+import org.jetbrains.jewel.bridge.LocalComponent
+import org.jetbrains.jewel.bridge.toComposeColor
+import org.jetbrains.jewel.foundation.ExperimentalJewelApi
+import org.jetbrains.jewel.foundation.modifier.trackComponentActivation
+import org.jetbrains.jewel.foundation.theme.JewelTheme
+import org.jetbrains.magicmetamodel.impl.workspacemodel.BuildTargetId
+import org.jetbrains.magicmetamodel.impl.workspacemodel.BuildTargetInfo
+import org.jetbrains.plugins.bsp.assets.BuildToolAssetsExtension
+import org.jetbrains.plugins.bsp.config.buildToolId
+import org.jetbrains.plugins.bsp.extension.points.withBuildToolIdOrDefault
+import org.jetbrains.plugins.bsp.jewel.ui.tree.TargetsTree
+import org.jetbrains.plugins.bsp.jewel.ui.tree.TreeGenerationParams
+import org.jetbrains.plugins.bsp.jewel.ui.tree.TreeTabName
+import org.jetbrains.plugins.bsp.services.MagicMetaModelService
+
+internal class ToolWindowPanelContent(val project: Project) {
+  private fun getTargetsFromMMM(): TargetsState {
+    val mmmValue = MagicMetaModelService.getInstance(project).value
+    return TargetsState(
+      loadedTargets = mmmValue.getAllLoadedTargets(),
+      invalidTargets = mmmValue.getAllInvalidTargets(),
+      notLoadedTargets = mmmValue.getAllNotLoadedTargets(),
+    )
+  }
+
+  private fun getTreeGenerationParams(treeTabName: TreeTabName): TreeGenerationParams {
+    val assetsExtension = BuildToolAssetsExtension.ep.withBuildToolIdOrDefault(project.buildToolId)
+    val icon = if (treeTabName == TreeTabName.LOADED_TARGETS) {
+      assetsExtension.loadedTargetIcon
+    } else {
+      assetsExtension.unloadedTargetIcon
+    }
+    return TreeGenerationParams(
+      targetIcon = icon,
+      invalidTargetIcon = assetsExtension.invalidTargetIcon,
+      buildToolId = project.buildToolId,
+      project = project,
+      treeTabName = treeTabName,
+    )
+  }
+
+  @OptIn(ExperimentalJewelApi::class)
+  @Composable
+  fun render() {
+    val bgColor by remember(JewelTheme.isDark) { mutableStateOf(JBColor.PanelBackground.toComposeColor()) }
+    Column(
+      modifier = Modifier.trackComponentActivation(LocalComponent.current)
+        .fillMaxSize()
+        .background(bgColor),
+      verticalArrangement = Arrangement.spacedBy(4.dp),
+    ) {
+      // ------------------------- Composable toolbar --------------------------
+      var panelState by remember { mutableStateOf(ToolbarTab.LOADED_TARGETS) }
+      ComposableToolbar(
+        panelState = panelState,
+        setPanelState = { panelState = it }
+      ).render()
+
+      var mmmTargetsState by remember { mutableStateOf(getTargetsFromMMM()) }
+      MagicMetaModelService.getInstance(project)
+        .value
+        .registerTargetLoadListener { mmmTargetsState = getTargetsFromMMM() }
+      val loadedTargetsTreeParams = remember { getTreeGenerationParams(TreeTabName.LOADED_TARGETS) }
+      val notLoadedTargetsTreeParams = remember { getTreeGenerationParams(TreeTabName.NOT_LOADED_TARGETS) }
+
+      targetsTabs(panelState, mmmTargetsState, loadedTargetsTreeParams, notLoadedTargetsTreeParams)
+    }
+  }
+
+  @Composable
+  private fun ColumnScope.targetsTabs(
+    panelState: ToolbarTab,
+    targets: TargetsState,
+    loadedTargetsTreeParams: TreeGenerationParams,
+    notLoadedTargetsTreeParams: TreeGenerationParams,
+  ) {
+    when (panelState) {
+      ToolbarTab.LOADED_TARGETS -> {
+        loadedTargetsTab(targets.loadedTargets, targets.invalidTargets, loadedTargetsTreeParams)
+      }
+
+      ToolbarTab.NOT_LOADED_TARGETS -> {
+        notLoadedTargetsTab(targets.notLoadedTargets, notLoadedTargetsTreeParams)
+      }
+    }
+  }
+}
+
+internal enum class ToolbarTab {
+  LOADED_TARGETS,
+  NOT_LOADED_TARGETS,
+}
+
+@Composable
+private fun ColumnScope.loadedTargetsTab(
+  loadedTargets: List<BuildTargetInfo>,
+  invalidTargets: List<BuildTargetId>,
+  treeGenerationParams: TreeGenerationParams,
+) {
+  TargetsTree(
+    generationParams = treeGenerationParams,
+    targets = loadedTargets,
+    invalidTargets = invalidTargets,
+  ).render()
+}
+
+@Composable
+private fun ColumnScope.notLoadedTargetsTab(
+  notLoadedTargets: List<BuildTargetInfo>,
+  treeGenerationParams: TreeGenerationParams,
+) {
+  TargetsTree(
+    generationParams = treeGenerationParams,
+    targets = notLoadedTargets,
+    invalidTargets = emptyList(),
+  ).render()
+}
+
+private data class TargetsState(
+  var loadedTargets: List<BuildTargetInfo>,
+  var invalidTargets: List<BuildTargetId>,
+  var notLoadedTargets: List<BuildTargetInfo>,
+)

--- a/src/main/kotlin/org/jetbrains/plugins/bsp/jewel/ui/tree/NodeData.kt
+++ b/src/main/kotlin/org/jetbrains/plugins/bsp/jewel/ui/tree/NodeData.kt
@@ -1,0 +1,22 @@
+package org.jetbrains.plugins.bsp.jewel.ui.tree
+
+import org.jetbrains.magicmetamodel.impl.workspacemodel.BuildTargetId
+import org.jetbrains.magicmetamodel.impl.workspacemodel.BuildTargetInfo
+
+internal interface NodeData
+
+internal data class DirectoryNodeData(val name: String) : NodeData {
+  override fun toString(): String = name
+}
+
+internal data class TargetNodeData(
+  val id: BuildTargetId,
+  val target: BuildTargetInfo?,
+  val displayName: String,
+  val isValid: Boolean,
+) : NodeData
+
+internal data class TargetNodeDataWithPath(
+  val nodeData: TargetNodeData,
+  val path: List<String>,
+)

--- a/src/main/kotlin/org/jetbrains/plugins/bsp/jewel/ui/tree/TargetActionPopupMenu.kt
+++ b/src/main/kotlin/org/jetbrains/plugins/bsp/jewel/ui/tree/TargetActionPopupMenu.kt
@@ -1,0 +1,216 @@
+package org.jetbrains.plugins.bsp.jewel.ui.tree
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.width
+import androidx.compose.material.Divider
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.text.style.TextDecoration
+import androidx.compose.ui.unit.dp
+import com.intellij.icons.AllIcons
+import com.intellij.openapi.diagnostic.logger
+import com.intellij.openapi.ide.CopyPasteManager
+import com.intellij.openapi.project.Project
+import com.intellij.util.ui.TextTransferable
+import org.jetbrains.jewel.ui.component.Icon
+import org.jetbrains.jewel.ui.component.PopupMenu
+import org.jetbrains.jewel.ui.component.Text
+import org.jetbrains.jewel.ui.component.items
+import org.jetbrains.magicmetamodel.impl.workspacemodel.BuildTargetInfo
+import org.jetbrains.magicmetamodel.impl.workspacemodel.ModuleCapabilities
+import org.jetbrains.magicmetamodel.impl.workspacemodel.toBsp4JTargetIdentifier
+import org.jetbrains.plugins.bsp.config.BspPluginBundle
+import org.jetbrains.plugins.bsp.server.tasks.runBuildTargetTask
+import org.jetbrains.plugins.bsp.services.BspCoroutineService
+
+internal class TargetActionPopupMenu(
+  private val project: Project,
+  // for which tree tab the popup menu is rendered
+  private val generatedTreeTabName: TreeTabName,
+  private var state: PopupMenuState,
+  private val setState: (PopupMenuState) -> Unit,
+) {
+  private companion object {
+    private val log = logger<TargetActionPopupMenu>()
+  }
+
+  private fun getActionsListForTarget(
+    treeTabName: TreeTabName,
+    targetCapabilities: ModuleCapabilities,
+  ): List<TargetAction> {
+    val actionList = mutableListOf<TargetAction>()
+    actionList.add(CopyTargetIdAction())
+    if (treeTabName == TreeTabName.LOADED_TARGETS) {
+      updateActionSetWithTargetCapabilities(targetCapabilities, actionList)
+    } else {
+      actionList.add(LoadTargetAction())
+    }
+    return actionList
+  }
+
+  private fun updateActionSetWithTargetCapabilities(
+    targetCapabilities: ModuleCapabilities,
+    actionList: MutableList<TargetAction>,
+  ) {
+    if (targetCapabilities.canCompile) {
+      actionList.add(BuildTargetAction())
+    }
+    if (targetCapabilities.canRun) {
+      actionList.add(RunTargetAction())
+    }
+    if (targetCapabilities.canTest) {
+      actionList.add(TestTargetAction())
+    }
+  }
+
+  @Composable
+  private fun renderActionPopupMenu(target: BuildTargetInfo) {
+    TargetAction.initProject(project)
+    val actions = remember { getActionsListForTarget(generatedTreeTabName, target.capabilities) }
+
+    if (state == PopupMenuState.VISIBLE) {
+      PopupMenu(
+        onDismissRequest = { setState(PopupMenuState.HIDDEN); true },
+        horizontalAlignment = Alignment.Start,
+        content = {
+          items(
+            actions,
+            isSelected = { false },
+            onItemClick = {
+              it.execute(target)
+            },
+          ) {
+            Row(
+              horizontalArrangement = Arrangement.spacedBy(4.dp, Alignment.Start),
+              verticalAlignment = Alignment.CenterVertically,
+            ) {
+              it.display()
+            }
+          }
+        },
+      )
+    }
+  }
+
+  @Composable
+  fun attach(target: BuildTargetInfo?) {
+    if (target != null) {
+      renderActionPopupMenu(target)
+    } else {
+      // todo: execute valid actions for invalid targets
+      log.warn("Can't render action popup menu for null target")
+    }
+  }
+}
+
+internal enum class PopupMenuState {
+  HIDDEN,
+  VISIBLE,
+}
+
+internal fun PopupMenuState.toggle(): PopupMenuState = when (this) {
+  PopupMenuState.HIDDEN -> PopupMenuState.VISIBLE
+  PopupMenuState.VISIBLE -> PopupMenuState.HIDDEN
+}
+
+private interface TargetAction {
+  val displayName: String
+  val iconPath: String
+
+  companion object {
+    val log = logger<TargetAction>()
+    var project: Project? = null
+      private set
+
+    fun initProject(newProjectVal: Project) = if (project == null) project = newProjectVal else Unit
+  }
+
+  @Composable
+  fun display() {
+    Icon(
+      resource = iconPath,
+      iconClass = AllIcons::class.java,
+      contentDescription = null,
+    )
+    Text(displayName)
+  }
+
+  fun execute(target: BuildTargetInfo)
+}
+
+private class CopyTargetIdAction : TargetAction {
+  override val displayName: String = BspPluginBundle.message("widget.copy.target.id")
+  override val iconPath: String = "actions/copy.svg"
+
+  @Composable
+  override fun display() {
+    Column(verticalArrangement = Arrangement.spacedBy(4.dp)) {
+      Row {
+        super.display()
+        Spacer(Modifier.width(24.dp))
+        // Currently copying target id does not work with the use of Ctrl+c
+        Text(text = "Ctrl+C", style = TextStyle(textDecoration = TextDecoration.LineThrough))
+      }
+      // Divider is currently a part of Row of Menu item, meaning it is highlighted when hovered
+      // in order to change it, one would have to modify JewelTheme MenuStyle,
+      // current MenuStyle is default for PopupMenu function
+      Divider(Modifier.height(1.dp).fillMaxWidth())
+    }
+  }
+
+  override fun execute(target: BuildTargetInfo) {
+    val clipboard = CopyPasteManager.getInstance()
+    val transferable = TextTransferable(target.id as CharSequence)
+    clipboard.setContents(transferable)
+  }
+}
+
+private class BuildTargetAction : TargetAction {
+  override val displayName: String = BspPluginBundle.message("widget.build.target.popup.message")
+  override val iconPath: String = "toolwindows/toolWindowBuild.svg"
+
+  override fun execute(target: BuildTargetInfo) {
+    val project = TargetAction.project!!
+    BspCoroutineService.getInstance(project).start {
+      runBuildTargetTask(listOf(target.id.toBsp4JTargetIdentifier()), project, TargetAction.log)
+    }
+  }
+}
+
+private class RunTargetAction : TargetAction {
+  override val displayName: String = BspPluginBundle.message("widget.run.target.popup.message")
+  override val iconPath: String = "runConfigurations/testState/run.svg"
+
+  override fun execute(target: BuildTargetInfo) {
+    println("Run action is yet not implemented. Triggered for target: $target ")
+  }
+}
+
+private class TestTargetAction : TargetAction {
+  override val displayName: String = BspPluginBundle.message("widget.test.target.popup.message")
+  override val iconPath: String = "runConfigurations/testState/run.svg"
+
+  override fun execute(target: BuildTargetInfo) {
+    println("Test action is yet not implemented. Triggered for target: $target")
+  }
+}
+
+private class LoadTargetAction : TargetAction {
+  override val displayName: String = BspPluginBundle.message("widget.load.target.popup.message")
+  override val iconPath: String = "actions/download.svg"
+
+  override fun execute(target: BuildTargetInfo) {
+    val project = TargetAction.project!!
+    BspCoroutineService.getInstance(project).start {
+      org.jetbrains.plugins.bsp.ui.actions.LoadTargetAction.loadTarget(project, target.id)
+    }
+  }
+}

--- a/src/main/kotlin/org/jetbrains/plugins/bsp/jewel/ui/tree/TargetsTree.kt
+++ b/src/main/kotlin/org/jetbrains/plugins/bsp/jewel/ui/tree/TargetsTree.kt
@@ -1,0 +1,135 @@
+package org.jetbrains.plugins.bsp.jewel.ui.tree
+
+import androidx.compose.foundation.ExperimentalFoundationApi
+import androidx.compose.foundation.PointerMatcher
+import androidx.compose.foundation.horizontalScroll
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.BoxScope
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.onClick
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.input.pointer.PointerButton
+import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.text.style.TextDecoration
+import androidx.compose.ui.unit.dp
+import com.intellij.icons.AllIcons
+import com.intellij.openapi.diagnostic.logger
+import com.intellij.openapi.project.Project
+import org.jetbrains.jewel.foundation.ExperimentalJewelApi
+import org.jetbrains.jewel.foundation.lazy.tree.Tree
+import org.jetbrains.jewel.ui.component.Icon
+import org.jetbrains.jewel.ui.component.LazyTree
+import org.jetbrains.jewel.ui.component.Text
+import org.jetbrains.magicmetamodel.impl.workspacemodel.BuildTargetId
+import org.jetbrains.magicmetamodel.impl.workspacemodel.BuildTargetInfo
+import org.jetbrains.plugins.bsp.assets.AssetIcon
+import org.jetbrains.plugins.bsp.extension.points.BuildToolId
+
+internal class TargetsTree(
+  private val generationParams: TreeGenerationParams,
+  private val targets: Collection<BuildTargetInfo>,
+  private val invalidTargets: Collection<BuildTargetId>,
+) {
+  private companion object {
+    val log = logger<TargetsTree>()
+    private val nodeElementsDistance = 4.dp
+  }
+
+  private fun generateTreeStructure(): Tree<NodeData> =
+    TargetsTreeStructure(generationParams.buildToolId, targets, invalidTargets).generate()
+
+  @OptIn(ExperimentalFoundationApi::class)
+  @Composable
+  private fun BoxScope.renderTargetNode(data: TargetNodeData) {
+    var popupMenuState by remember { mutableStateOf(PopupMenuState.HIDDEN) }
+    // views the popup menu for the target
+    val onRightMouseClickModifier = Modifier.onClick(
+      matcher = PointerMatcher.mouse(PointerButton.Secondary)
+    ) { popupMenuState = popupMenuState.toggle() }
+
+    Row(
+      horizontalArrangement = Arrangement.spacedBy(nodeElementsDistance),
+      modifier = onRightMouseClickModifier,
+    ) {
+      // ideally icon next to the target should be the icon of the build tool, but currently in Jewel
+      // rendering the icon requires a icon path which is not provided within assetsExtension.
+      // Therefore, currently new `AssetIcon` class is used. See `org.jetbrains.plugins.bsp.assets.AssetIcon`
+      val assetIcon = if (data.isValid) generationParams.targetIcon else generationParams.invalidTargetIcon
+      val textStyle = if (data.isValid) TextStyle() else TextStyle(textDecoration = TextDecoration.LineThrough)
+
+      Icon(resource = assetIcon.path, iconClass = assetIcon.clazz, contentDescription = null)
+      Text(text = data.displayName, style = textStyle)
+      TargetActionPopupMenu(
+        project = generationParams.project,
+        generatedTreeTabName = generationParams.treeTabName,
+        state = popupMenuState,
+        setState = { popupMenuState = it })
+        .attach(data.target)
+    }
+  }
+
+  @Composable
+  private fun BoxScope.renderDirectoryNode(data: DirectoryNodeData) {
+    Row(horizontalArrangement = Arrangement.spacedBy(nodeElementsDistance)) {
+      Icon("nodes/folder.svg", null, AllIcons::class.java)
+      Text(data.toString())
+    }
+  }
+
+  @Composable
+  private fun renderNode(element: Tree.Element<NodeData>) {
+    val warn = { log.warn("Invalid tree element type passed during UI target tree render, rendering empty node") }
+    Box(Modifier.fillMaxWidth()) {
+      when (element) {
+        is Tree.Element.Leaf<*> -> {
+          if (element.data is TargetNodeData) renderTargetNode(element.data as TargetNodeData)
+          else warn()
+        }
+        is Tree.Element.Node<*> -> {
+          if (element.data is DirectoryNodeData) renderDirectoryNode(element.data as DirectoryNodeData)
+          else warn()
+        }
+      }
+    }
+  }
+
+  @OptIn(ExperimentalJewelApi::class)
+  @Composable
+  fun render() {
+    Column(
+      verticalArrangement = Arrangement.spacedBy(4.dp),
+    ) {
+      val tree = remember { generateTreeStructure() }
+      val scrollState = rememberScrollState()
+      LazyTree(
+        tree = tree,
+        modifier = Modifier.fillMaxWidth().horizontalScroll(scrollState),
+        onElementClick = {},
+        onElementDoubleClick = {},
+        nodeContent = { renderNode(it) }
+      )
+    }
+  }
+}
+
+internal enum class TreeTabName {
+  LOADED_TARGETS,
+  NOT_LOADED_TARGETS,
+}
+
+internal data class TreeGenerationParams(
+  val targetIcon: AssetIcon,
+  val invalidTargetIcon: AssetIcon,
+  val buildToolId: BuildToolId,
+  val project: Project,
+  val treeTabName: TreeTabName,
+)

--- a/src/main/kotlin/org/jetbrains/plugins/bsp/jewel/ui/tree/TargetsTreeStructure.kt
+++ b/src/main/kotlin/org/jetbrains/plugins/bsp/jewel/ui/tree/TargetsTreeStructure.kt
@@ -1,0 +1,126 @@
+package org.jetbrains.plugins.bsp.jewel.ui.tree
+
+import org.jetbrains.jewel.foundation.lazy.tree.ChildrenGeneratorScope
+import org.jetbrains.jewel.foundation.lazy.tree.Tree
+import org.jetbrains.jewel.foundation.lazy.tree.TreeBuilder
+import org.jetbrains.jewel.foundation.lazy.tree.buildTree
+import org.jetbrains.magicmetamodel.impl.workspacemodel.BuildTargetId
+import org.jetbrains.magicmetamodel.impl.workspacemodel.BuildTargetInfo
+import org.jetbrains.plugins.bsp.extension.points.BuildTargetClassifierExtension
+import org.jetbrains.plugins.bsp.extension.points.BuildToolId
+import org.jetbrains.plugins.bsp.extension.points.withBuildToolIdOrDefault
+
+private typealias TreeNode = TreeBuilder.Element<NodeData>
+private typealias DirectoryTreeNode = TreeBuilder.Element.Node<NodeData>
+private typealias LeafTreeNode = TreeBuilder.Element.Leaf<NodeData>
+private typealias ChildrenGenerator = ChildrenGeneratorScope<NodeData>.() -> Unit
+
+internal class TargetsTreeStructure(
+  private val buildToolId: BuildToolId,
+  private val targets: Collection<BuildTargetInfo>,
+  private val invalidTargets: Collection<BuildTargetId>,
+) {
+  private var separator: String? = null
+
+  fun generate(): Tree<NodeData> {
+    val bspBuildTargetClassifier = BuildTargetClassifierExtension.ep.withBuildToolIdOrDefault(buildToolId)
+    separator = bspBuildTargetClassifier.separator
+
+    val targetsCombined = targets.map {
+      TargetNodeDataWithPath(
+        nodeData = TargetNodeData(it.id, it, bspBuildTargetClassifier.calculateBuildTargetName(it.id), true),
+        path = bspBuildTargetClassifier.calculateBuildTargetPath(it.id),
+      )
+    } + invalidTargets.map {
+      TargetNodeDataWithPath(
+        nodeData = TargetNodeData(it, null, bspBuildTargetClassifier.calculateBuildTargetName(it), false),
+        bspBuildTargetClassifier.calculateBuildTargetPath(it),
+      )
+    }
+    return treeStructureFromIdentifiers(targetsCombined)
+  }
+
+  private fun treeStructureFromIdentifiers(
+    targetsNodes: List<TargetNodeDataWithPath>,
+  ): Tree<NodeData> {
+    val pathToIdentifierMap = targetsNodes.groupBy { it.path.firstOrNull() }
+    val sortedDirs = pathToIdentifierMap.keys
+      .filterNotNull()
+      .sorted()
+
+    return buildTree {
+      for (dir in sortedDirs) {
+        pathToIdentifierMap[dir]?.let {
+          val directoryNode = generateDirectoryNode(it, dir, 0)
+          add(directoryNode)
+        }
+      }
+      pathToIdentifierMap[null]?.forEach { addLeaf(it.nodeData) }
+    }
+  }
+
+  private fun generateDirectoryNode(
+    targets: List<TargetNodeDataWithPath>,
+    dirname: String,
+    depth: Int,
+  ): TreeBuilder.Element.Node<NodeData> {
+    val pathToIdentifierMap = targets.groupBy { it.path.getOrNull(depth + 1) }
+    val childrenNodes: List<TreeBuilder.Element<NodeData>> = generateChildrenNodes(pathToIdentifierMap, depth)
+    val (nodeName, childrenGenerator) = simplifyNodeParametersIfOnlyOneChild(dirname, childrenNodes)
+
+    return TreeBuilder.Element.Node(
+      data = DirectoryNodeData(nodeName),
+      id = null,
+      childrenGenerator = childrenGenerator)
+  }
+
+  private fun childrenGenerator(childrenList: List<TreeNode>): ChildrenGenerator {
+    return {
+      childrenList.forEach { add(it) }
+    }
+  }
+
+  private fun simplifyNodeParametersIfOnlyOneChild(
+    dirname: String,
+    childrenList: List<TreeNode>,
+  ): Pair<String, ChildrenGenerator> {
+    if (separator != null && childrenList.size == 1) {
+      val onlyChild = childrenList.first() as? DirectoryTreeNode
+      if (onlyChild != null) {
+        val newName = "${dirname}${separator}${onlyChild.data}"
+        return Pair(newName, onlyChild.childrenGenerator)
+      }
+    }
+    return Pair(dirname, childrenGenerator(childrenList))
+  }
+
+  private fun generateChildrenNodes(
+    pathToIdentifierMap: Map<String?, List<TargetNodeDataWithPath>>,
+    depth: Int,
+  ): List<TreeNode> {
+    val childrenDirectoryNodes =
+      generateChildrenDirectoryNodes(pathToIdentifierMap, depth)
+    val childrenTargetNodes =
+      generateChildrenTargetNodes(pathToIdentifierMap)
+    return childrenDirectoryNodes + childrenTargetNodes
+  }
+
+  private fun generateChildrenDirectoryNodes(
+    pathToIdentifierMap: Map<String?, List<TargetNodeDataWithPath>>,
+    depth: Int,
+  ): List<TreeNode> =
+    pathToIdentifierMap
+      .keys
+      .filterNotNull()
+      .sorted()
+      .mapNotNull { dir ->
+        pathToIdentifierMap[dir]?.let {
+          generateDirectoryNode(it, dir, depth + 1)
+        }
+      }
+
+  private fun generateChildrenTargetNodes(
+    pathToIdentifierMap: Map<String?, List<TargetNodeDataWithPath>>,
+  ): List<TreeNode> =
+    pathToIdentifierMap[null]?.map { LeafTreeNode(it.nodeData, null) } ?: emptyList()
+}

--- a/src/main/kotlin/org/jetbrains/plugins/bsp/ui/widgets/tool/window/components/BspToolWindowPanel.kt
+++ b/src/main/kotlin/org/jetbrains/plugins/bsp/ui/widgets/tool/window/components/BspToolWindowPanel.kt
@@ -5,6 +5,7 @@ import com.intellij.openapi.actionSystem.AnAction
 import com.intellij.openapi.actionSystem.DefaultActionGroup
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.ui.SimpleToolWindowPanel
+import com.intellij.openapi.util.IconLoader
 import org.jetbrains.plugins.bsp.assets.BuildToolAssetsExtension
 import org.jetbrains.plugins.bsp.config.BspPluginBundle
 import org.jetbrains.plugins.bsp.config.BspPluginIcons
@@ -40,10 +41,17 @@ private class ListsUpdater(
     val magicMetaModel = MagicMetaModelService.getInstance(project).value
     val assetsExtension = BuildToolAssetsExtension.ep.withBuildToolIdOrDefault(project.buildToolId)
 
+    // This is just temporary for the purpose of Jewel UI proof of concept, icons shouldn't be loaded here
+    // as it slows down the UI. One extra warning emitted.
+    val invalidIcon =
+      IconLoader.getIcon(assetsExtension.invalidTargetIcon.path, assetsExtension.invalidTargetIcon.clazz)
+    val notLoadedTargetIcon =
+      IconLoader.getIcon(assetsExtension.unloadedTargetIcon.path, assetsExtension.unloadedTargetIcon.clazz)
+
     loadedTargetsPanel =
       BspPanelComponent(
-        targetIcon = assetsExtension.loadedTargetIcon,
-        invalidTargetIcon = assetsExtension.invalidTargetIcon,
+        targetIcon = BspPluginIcons.bsp,
+        invalidTargetIcon = invalidIcon,
         buildToolId = project.buildToolId,
         toolName = assetsExtension.presentableName,
         targets = magicMetaModel.getAllLoadedTargets(),
@@ -54,8 +62,8 @@ private class ListsUpdater(
 
     notLoadedTargetsPanel =
       BspPanelComponent(
-        targetIcon = assetsExtension.unloadedTargetIcon,
-        invalidTargetIcon = assetsExtension.invalidTargetIcon,
+        targetIcon = notLoadedTargetIcon,
+        invalidTargetIcon = invalidIcon,
         buildToolId = project.buildToolId,
         toolName = assetsExtension.presentableName,
         targets = magicMetaModel.getAllNotLoadedTargets(),

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -82,6 +82,8 @@
 
     <toolWindowAllowlist id="BSP"/>
 
+    <toolWindowAllowlist id="BSP-Jewel"/>
+
     <iconMapper mappingFile="BSPIconMappings.json"/>
 
     <notificationGroup displayType="BALLOON" id="BSP Plugin"/>


### PR DESCRIPTION
This is a draft PR of _proof of concept_ reimplementation of the Bsp toolwindow in compose with the use of Jewel library. More details can be found in the attached file.
[JewelComposeToolwindowReimplementationDoc.md](https://github.com/JetBrains/intellij-bsp/files/13709959/JewelComposeToolwindowReimplementationDoc.md)
